### PR TITLE
old collisionModel loader

### DIFF
--- a/neo/cm/CollisionModel_load.cpp
+++ b/neo/cm/CollisionModel_load.cpp
@@ -4186,9 +4186,8 @@ void idCollisionModelManagerLocal::BuildModels( const idMapFile* mapFile )
 	idTimer timer;
 	timer.Start();
 	
-	if( !LoadCollisionModelFile( mapFile->GetName(), mapFile->GetGeometryCRC() ) )
+	if( !OldLoadCollisionModelFile( mapFile->GetName(), mapFile->GetGeometryCRC() ) )
 	{
-	
 		if( !mapFile->GetNumEntities() )
 		{
 			return;

--- a/neo/cm/CollisionModel_local.h
+++ b/neo/cm/CollisionModel_local.h
@@ -528,6 +528,7 @@ private:			// CollisionMap_files.cpp
 	void			ParseBrushes( idLexer* src, cm_model_t* model );
 	cm_model_t* 	ParseCollisionModel( idLexer* src );
 	bool			LoadCollisionModelFile( const char* name, unsigned int mapFileCRC );
+	bool                    OldLoadCollisionModelFile( const char *name, unsigned int mapFileCRC );
 	
 private:			// CollisionMap_debug
 	int				ContentsFromString( const char* string ) const;


### PR DESCRIPTION
added old version of collisionModel file loader, should be removed in future for favoring the binary .bcmodel loader once there is a writer for it