### PR TITLE
Small quality of life improvement for kdevelop users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@ GRTAGS
 GSYMS
 GTAGS
 HTML/
-neo/.kdev4
-neo/neo.kdev4
+.kdev4
+*.kdev4
 OpenTechEngine.pdb
 *.db
 OpenTechEngine.exe


### PR DESCRIPTION
This is a small fix which adjusts the path used in .gitignore for kdevelop specific configuration files. I am not sure if something changed in how kdevelop handles .kdev4 files but the current .gitignore file doesn't work with atleast kdevelop 5.1.0 as these files don't get placed in neo but in the root directory where neo is. 

I also made the name of the configuration file customizable, as in kdevelop you can change the default project name to something more descriptive if you wish, its quite awkward to have something like neo/neo/something_else as file path in the project overview of kdevelop.