### PR TITLE
fixed compilation error with gcc version 7.1.1

### DIFF
--- a/neo/idlib/StrStatic.h
+++ b/neo/idlib/StrStatic.h
@@ -102,7 +102,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( b );
+		idStr::operator=( idStr( b ) );
 	}
 	
 	ID_INLINE	explicit idStrStatic( const char c ) :
@@ -110,7 +110,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( c );
+		idStr::operator=( idStr( c ) );
 	}
 	
 	ID_INLINE	explicit idStrStatic( const int i ) :
@@ -118,7 +118,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( i );
+		idStr::operator=( idStr( i ) );
 	}
 	
 	ID_INLINE	explicit idStrStatic( const unsigned u ) :
@@ -126,7 +126,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( u );
+		idStr::operator=( idStr( u ) );
 	}
 	
 	ID_INLINE	explicit idStrStatic( const float f ) :
@@ -134,7 +134,7 @@ public:
 	{
 		buffer[ 0 ] = '\0';
 		SetStaticBuffer( buffer, _size_ );
-		idStr::operator=( f );
+		idStr::operator=( idStr( f ) );
 	}
 	
 private:

--- a/neo/tools/compilers/dmap/dmap.cpp
+++ b/neo/tools/compilers/dmap/dmap.cpp
@@ -364,7 +364,7 @@ void Dmap( const idCmdArgs& args )
 	// if this isn't a regioned map, delete the last saved region map
 	if( passedName.Right( 4 ) != ".reg" )
 	{
-		std::sprintf( path, "%s.reg", dmapGlobals.mapFileBase );
+		idStr::snPrintf( path, sizeof( path ), "%s.reg", dmapGlobals.mapFileBase );
 		fileSystem->RemoveFile( path );
 	}
 	else
@@ -376,7 +376,7 @@ void Dmap( const idCmdArgs& args )
 	passedName = stripped;
 	
 	// delete any old line leak files
-	std::sprintf( path, "%s.lin", dmapGlobals.mapFileBase );
+	idStr::snPrintf( path, sizeof( path ), "%s.lin", dmapGlobals.mapFileBase );
 	fileSystem->RemoveFile( path );
 	
 	// delete any old generated binary proc files


### PR DESCRIPTION
Pretty weird issue with gcc 7.1.1 on arch linux, took me a while to figure out.

The stuff regading dmap is especially weird, why the hell would we use stdlib print calls in there?