### PR TITLE
macOS fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-build*
+build/*
 eclipse*
+
 neo/ipch
 
 Doom3BFG.exe
-
+base/base
 base/generated/
 
 GPATH
@@ -16,3 +17,5 @@ HTML/
 OpenTechEngine.pdb
 *.db
 OpenTechEngine.exe
+
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ os:
   - osx
 matrix:
   fast_finish: true
-  allow_failures:
-    - os: osx
 compiler:
   - gcc
   - clang
@@ -29,8 +27,7 @@ addons:
 
   apt:
      packages: [
-        # isnt cmake already included in the c++ build image that we use?
-        libsdl2-dev libopenal-dev cmake
+        libsdl2-dev libopenal-dev
      ]
 
 before_install:
@@ -43,7 +40,8 @@ install:
 
 script:
  - mkdir -p build && cd build
- - if [ "$CXX" = "mingw" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=../scripts/mingw32.toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DBUNDLED_FREETYPE=ON -DBUNDLED_OPENAL=ON ../ ;else cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ../;fi
+ - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash ../.travis/scripts/build.linux.sh ; fi
+ - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash ../.travis/scripts/build.osx.sh ; fi
  - make
 
 after_success:

--- a/.travis/scripts/build.linux.sh
+++ b/.travis/scripts/build.linux.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ "$CXX" = "g++" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ../; fi
+if [ "$CXX" = "clang++" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ../; fi
+if [ "$CXX" = "mingw" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=../scripts/mingw32.toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DBUNDLED_FREETYPE=ON -DBUNDLED_OPENAL=ON ../ ; fi

--- a/.travis/scripts/build.osx.sh
+++ b/.travis/scripts/build.osx.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ "$CXX" = "g++" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ../; fi
+if [ "$CXX" = "clang++" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ../; fi
+if [ "$CXX" = "mingw" ]; then echo -e 'all :\n\ttrue' > Makefile ; fi

--- a/.travis/scripts/install.osx.sh
+++ b/.travis/scripts/install.osx.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo "no-op"
+brew upgrade
+brew install sdl2 glew

--- a/.travis/scripts/install.ubuntu.sh
+++ b/.travis/scripts/install.ubuntu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-if [ "$CXX" = "g++" ]; then sudo apt-get install -qqy gcc g++ rpm; fi
+if [ "$CXX" = "g++" ]; then sudo apt-get install -qqy rpm; fi
+if [ "$CXX" = "clang++" ]; then sudo apt-get install -qqy rpm; fi
 if [ "$CXX" = "mingw" ]; then sudo apt-get install -qqy g++-mingw-w64-x86-64 nsis; fi
-if [ "$CXX" = "clang++" ]; then sudo apt-get install -qqy clang rpm; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,8 @@ option(IDTOOLS
 option(CEGUI
   "Use cegui" ON)
 
-if(WIN32 AND (CMAKE_COMPILER_IS_GNUCC OR NOT $ENV{VSINSTALLDIR}))
+if((WIN32 AND (CMAKE_COMPILER_IS_GNUCC OR NOT $ENV{VSINSTALLDIR})) OR
+${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # breakpad doesn't work on mingw out of the box
   # and it requires DIA SDK which is under VSINSTALLDIR
   option(BREAKPAD
@@ -70,7 +71,7 @@ option(BUNDLED_GLEW
 
 option(BUNDLED_OGGVORBIS
   "Use bundled oggvorbis" OFF)
-  
+
 option(BUNDLED_OPENAL
   "Use bundled openal" OFF)
 
@@ -86,7 +87,7 @@ option(BUNDLED_SDL
 option(BUNDLED_CEGUI
   "Use bundled CEGUI" ON)
 
-  
+
 ################################################################################
 
 message(STATUS CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE})
@@ -104,7 +105,7 @@ if(BUNDLED_ZLIB)
 endif()
 
 # libpng
-if(BUNDLED_PNG)	
+if(BUNDLED_PNG)
   add_subdirectory(libs/png)
 endif()
 
@@ -133,12 +134,12 @@ if(BUNDLED_CEGUI)
 
   # freetype, if not found, we build ours
   find_package(Freetype)
-  
+
   if(NOT FREETYPE_FOUND)
     add_subdirectory(libs/freetype)
     set(BUNDLED_FREETYPE ON CACHE BOOL "Select BUNDLED_FREETYPE for cegui" FORCE)
   endif()
-  
+
   add_subdirectory(libs/cegui)
 endif()
 
@@ -169,6 +170,7 @@ if(UNIX)
   add_custom_target(
     "OpenTechEngine_symlinks" ALL
     COMMAND ln -sf "${CMAKE_SOURCE_DIR}/base" "${CMAKE_BINARY_DIR}/base"
+    COMMAND ln -sf "${CMAKE_SOURCE_DIR}/base" "${CMAKE_BINARY_DIR}/neo/base"
     COMMAND ln -sf "${CMAKE_BINARY_DIR}/neo/OpenTechEngine" "${CMAKE_BINARY_DIR}/OpenTechEngine"
     )
   if(BUNDLED_CEGUI)

--- a/neo/sound/OpenAL/AL_SoundHardware.cpp
+++ b/neo/sound/OpenAL/AL_SoundHardware.cpp
@@ -28,8 +28,13 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 #pragma hdrstop
+#ifdef __APPLE__
+#include <OpenAL/al.h>
+#include <OpenAL/alc.h>
+#else
 #include <AL/al.h>
 #include <AL/alc.h>
+#endif
 #include <cstring>
 
 #include "../framework/CVarSystem.h"

--- a/neo/sound/OpenAL/AL_SoundSample.cpp
+++ b/neo/sound/OpenAL/AL_SoundSample.cpp
@@ -29,7 +29,11 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 #pragma hdrstop
+#ifdef __APPLE__
+#include <OpenAL/al.h>
+#else
 #include <AL/al.h>
+#endif
 #include <cmath>
 #include <cstring>
 

--- a/neo/sound/OpenAL/AL_SoundVoice.cpp
+++ b/neo/sound/OpenAL/AL_SoundVoice.cpp
@@ -27,7 +27,11 @@ If you have questions concerning this license or the applicable additional terms
 ===========================================================================
 */
 #pragma hdrstop
+#ifdef __APPLE__
+#include <OpenAL/al.h>
+#else
 #include <AL/al.h>
+#endif
 #include <cstddef>
 
 #include "../framework/CVarSystem.h"

--- a/neo/sys/posix/platform_osx.cpp
+++ b/neo/sys/posix/platform_osx.cpp
@@ -46,6 +46,9 @@ If you have questions concerning this license or the applicable additional terms
 // DG: needed for Sys_ReLaunch()
 #include <dirent.h>
 
+#include "../../framework/CmdSystem.h"
+#include "../../framework/Common.h"
+
 namespace BFG
 {
 
@@ -443,6 +446,9 @@ int clock_gettime( clk_id_t clock, struct timespec* tp )
 main
 ===============
 */
+#ifdef __cplusplus
+    extern "C"
+#endif
 int main( int argc, const char** argv )
 {
 	// DG: needed for Sys_ReLaunch()

--- a/neo/sys/posix/posix_main.cpp
+++ b/neo/sys/posix/posix_main.cpp
@@ -66,7 +66,7 @@ If you have questions concerning this license or the applicable additional terms
 #endif
 
 #if defined(__APPLE__)
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #endif
 
 #include <sys/statvfs.h>

--- a/neo/sys/posix/posix_public.h
+++ b/neo/sys/posix/posix_public.h
@@ -31,6 +31,8 @@ If you have questions concerning this license or the applicable additional terms
 
 #include <csignal>
 
+#include "../sys_public.h"
+
 namespace BFG
 {
 

--- a/neo/unix.cmake
+++ b/neo/unix.cmake
@@ -11,7 +11,7 @@ include_directories(${OPENGL_INCLUDE_DIRS})
 if(FFMPEG)
   find_package(FFMPEG REQUIRED)
   add_definitions(-DUSE_FFMPEG)
-  
+
   include_directories(${FFMPEG_INCLUDE_DIR})
   link_directories(${FFMPEG_LIBRARIES_DIRS})
 endif()
@@ -48,10 +48,14 @@ list(APPEND OpenTechBFG_SOURCES
   ${SDL_INCLUDES} ${SDL_SOURCES})
 
 if(OPENAL)
-  find_package(OpenAL REQUIRED)
   add_definitions(-DUSE_OPENAL)
+  if(BUNDLED_OPENAL)
+    include_directories(${CMAKE_SOURCE_DIR}/libs/openal-soft/openal-soft.git/include)
+  else()
+    find_package(OpenAL REQUIRED)
+  endif()
   set(OPENAL_LIBRARY openal)
-  
+
   list(APPEND OpenTechBFG_INCLUDES ${OPENAL_INCLUDES})
   list(APPEND OpenTechBFG_SOURCES ${OPENAL_SOURCES})
 else()
@@ -66,7 +70,6 @@ if(BREAKPAD)
   set(BREAKPAD_LIBRARY breakpad)
   link_directories(${CMAKE_BINARY_DIR}/libs/breakpad)
 endif()
-#endif()
 
 list(REMOVE_DUPLICATES OpenTechBFG_SOURCES)
 
@@ -106,6 +109,5 @@ target_link_libraries(OpenTechEngine
   ${CEGUIGLR_LIBRARY}
   imgui
   )
-#endif()
 
 install (TARGETS OpenTechEngine RUNTIME DESTINATION bin COMPONENT OpenTechEngine)

--- a/scripts/cmake-macOS-debug-nocegui.sh
+++ b/scripts/cmake-macOS-debug-nocegui.sh
@@ -1,0 +1,5 @@
+cd ..
+rm -rf build
+mkdir build
+cd build
+cmake -D CMAKE_OSX_DEPLOYMENT_TARGET="10.9" -D CMAKE_OSX_SYSROOT="macosx10.13" -D CMAKE_BUILD_TYPE=Debug -DBREAKPAD=OFF -DCEGUI=OFF -DBUNDLED_CEGUI=OFF -G Xcode ../


### PR DESCRIPTION
Tested these fixes on my local machine, a MacBook Pro 13' from 2017. Currently OTE will only build on macOS when using sdl2. See my comment in neo/sys/posix/posix_main.cpp.