### PR TITLE
Enable sdl2 per default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
       name: "OpenTechEngine/OpenTechBFG"
       description: "Build submitted via Travis CI"
     notification_email: kordex@gmail.com
-    build_command_prepend: 'mkdir build && cd build &&  if [ \"$CXX\" = \"mingw\" ]; then cmake -G \"Eclipse CDT4 - Unix Makefiles\" -DCMAKE_TOOLCHAIN_FILE=../scripts/mingw32.toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DSDL2=OFF -DBUNDLED_FREETYPE=ON -DBUNDLED_OPENAL=ON ../ ;else cmake -G \"Eclipse CDT4 - Unix Makefiles\" -DCMAKE_BUILD_TYPE=Debug -DSDL2=OFF ../;fi'
+    build_command_prepend: 'mkdir build && cd build &&  if [ \"$CXX\" = \"mingw\" ]; then cmake -G \"Eclipse CDT4 - Unix Makefiles\" -DCMAKE_TOOLCHAIN_FILE=../scripts/mingw32.toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DBUNDLED_FREETYPE=ON -DBUNDLED_OPENAL=ON ../ ;else cmake -G \"Eclipse CDT4 - Unix Makefiles\" -DCMAKE_BUILD_TYPE=Debug ../;fi'
     build_command:   "make -j 9"
     branch_pattern: coverity
 
@@ -37,7 +37,7 @@ install:
 
 script: 
  - mkdir -p build && cd build
- - if [ "$CXX" = "mingw" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=../scripts/mingw32.toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DSDL2=OFF -DBUNDLED_FREETYPE=ON -DBUNDLED_OPENAL=ON ../ ;else cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DSDL2=OFF ../;fi
+ - if [ "$CXX" = "mingw" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=../scripts/mingw32.toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DBUNDLED_FREETYPE=ON -DBUNDLED_OPENAL=ON ../ ;else cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ../;fi
  - make
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 matrix:
   fast_finish: true
   allow_failures:
-    - os: osx  
+    - os: osx
 compiler:
   - gcc
   - clang
@@ -27,6 +27,12 @@ addons:
     build_command:   "make -j 9"
     branch_pattern: coverity
 
+  apt:
+     packages: [
+        # isnt cmake already included in the c++ build image that we use?
+        libsdl2-dev libopenal-dev cmake
+     ]
+
 before_install:
   # this is allowed to fail so that pull requests can be built too
   - openssl aes-256-cbc -K $encrypted_24fdd259e571_key -iv $encrypted_24fdd259e571_iv -in .travis/id_rsa.enc -out .travis/id_rsa -d || true
@@ -35,7 +41,7 @@ install:
  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash .travis/scripts/install.ubuntu.sh ; fi
  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bash .travis/scripts/install.osx.sh ; fi
 
-script: 
+script:
  - mkdir -p build && cd build
  - if [ "$CXX" = "mingw" ]; then cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=../scripts/mingw32.toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -DBUNDLED_FREETYPE=ON -DBUNDLED_OPENAL=ON ../ ;else cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ../;fi
  - make

--- a/.travis/scripts/install.ubuntu.sh
+++ b/.travis/scripts/install.ubuntu.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
+# default for the c++ image is already trusty these days
 # to trusty
 
-if [ "$CXX" = "g++" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
-if [ "$CXX" = "mingw" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
-if [ "$CXX" = "clang++" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
+# if [ "$CXX" = "g++" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
+# if [ "$CXX" = "mingw" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
+# if [ "$CXX" = "clang++" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
 
-sudo apt-get update -qq
-sudo apt-get install libsdl2-dev libopenal-dev cmake
+# sudo apt-get update -qq
+# sudo apt-get install libsdl2-dev libopenal-dev cmake
 
 if [ "$CXX" = "g++" ]; then sudo apt-get install -qqy gcc g++ rpm; fi
 if [ "$CXX" = "mingw" ]; then sudo apt-get install -qqy g++-mingw-w64-x86-64 nsis; fi
 if [ "$CXX" = "clang++" ]; then sudo apt-get install -qqy clang rpm; fi
-

--- a/.travis/scripts/install.ubuntu.sh
+++ b/.travis/scripts/install.ubuntu.sh
@@ -7,7 +7,7 @@ if [ "$CXX" = "mingw" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.
 if [ "$CXX" = "clang++" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
 
 sudo apt-get update -qq
-sudo apt-get install libsdl1.2-dev libopenal-dev cmake
+sudo apt-get install libsdl2-dev libopenal-dev cmake
 
 if [ "$CXX" = "g++" ]; then sudo apt-get install -qqy gcc g++ rpm; fi
 if [ "$CXX" = "mingw" ]; then sudo apt-get install -qqy g++-mingw-w64-x86-64 nsis; fi

--- a/.travis/scripts/install.ubuntu.sh
+++ b/.travis/scripts/install.ubuntu.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-# default for the c++ image is already trusty these days
-# to trusty
-
-# if [ "$CXX" = "g++" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
-# if [ "$CXX" = "mingw" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
-# if [ "$CXX" = "clang++" ]; then sudo sed -i 's/precise/trusty/g' /etc/apt/sources.list; fi
-
-# sudo apt-get update -qq
-# sudo apt-get install libsdl2-dev libopenal-dev cmake
-
 if [ "$CXX" = "g++" ]; then sudo apt-get install -qqy gcc g++ rpm; fi
 if [ "$CXX" = "mingw" ]; then sudo apt-get install -qqy g++-mingw-w64-x86-64 nsis; fi
 if [ "$CXX" = "clang++" ]; then sudo apt-get install -qqy clang rpm; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ option(MONOLITH
   "Embed game logic into main executable" ON)
 
 option(SDL2
-    "Use SDL2 instead of SDL1.2" ON)
+  "Use SDL2 instead of SDL1.2" ON)
 
 option(OPENAL
   "Use OpenAL soft instead of XAudio2" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ option(MONOLITH
   "Embed game logic into main executable" ON)
 
 option(SDL2
-  "Use SDL2 instead of SDL1.2" OFF)
+    "Use SDL2 instead of SDL1.2" ON)
 
 option(OPENAL
   "Use OpenAL soft instead of XAudio2" OFF)

--- a/scripts/cmake-eclipse-linux-debug.sh
+++ b/scripts/cmake-eclipse-linux-debug.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf build
 mkdir build
 cd build
-cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DSDL2=OFF ../
+cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug ../

--- a/scripts/cmake-eclipse-linux-profile.sh
+++ b/scripts/cmake-eclipse-linux-profile.sh
@@ -3,4 +3,4 @@ rm -rf build
 mkdir build
 cd build
 # -DCMAKE_INSTALL_PREFIX="/opt/OpenTechEngine/OpenTechBFG"
-cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSDL2=OFF ../
+cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo ../

--- a/scripts/cmake-linux-release.sh
+++ b/scripts/cmake-linux-release.sh
@@ -2,4 +2,4 @@ cd ..
 rm -rf build
 mkdir build
 cd build
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DSDL2=OFF ../
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ../


### PR DESCRIPTION
This pr will enable sdl2 per default, for now i just wanna check if everything works on CI. macOS doesnt have CI yet, thats something i will tackle later on, but there are also some open questions regarding AppVeyor/Travis regarding the windows build. The build for this pr will help me understand whats going on as i cant test on all platforms myself.