### PR TITLE
Sound device

### DIFF
--- a/neo/sound/OpenAL/AL_SoundHardware.cpp
+++ b/neo/sound/OpenAL/AL_SoundHardware.cpp
@@ -252,8 +252,6 @@ void idSoundHardware_OpenAL::Init()
 
 	idSoundHardware_OpenAL::OpenBestDevice();
 
-	CheckALErrors(); //TODO no need for this when it works
-
 	if( openalDevice == NULL )
 	{
 		common->FatalError( "idSoundHardware_OpenAL::Init: alcOpenDevice() failed\n" );
@@ -350,29 +348,24 @@ idSoundHardware_OpenAL::Shutdown
 */
 void idSoundHardware_OpenAL::Shutdown()
 {
+	zombieVoices.Clear();
+	freeVoices.Clear();
 	for( int i = 0; i < voices.Num(); i++ )
 	{
 		voices[ i ].DestroyInternal();
 	}
 	voices.Clear();
-	freeVoices.Clear();
-	zombieVoices.Clear();
 	
 	alcMakeContextCurrent( NULL );
 	
 	alcDestroyContext( openalContext );
 	openalContext = NULL;
 
-	if( openalDevice != NULL ) {
-		common->Printf( "sound shutdown: openalDevice active, closing it\n" );
-		alcCloseDevice( openalDevice );
-		openalDevice = NULL;
-		common->Printf( "sound shutdown: openalDevice closed and nullified\n" );
-	}
+	alcCloseDevice( openalDevice );
+	openalDevice = NULL;
 
 	OpenALDeviceList.Clear();
 
-	CheckALErrors();
 	/*
 	if( vuMeterRMS != NULL )
 	{

--- a/neo/sound/OpenAL/AL_SoundHardware.cpp
+++ b/neo/sound/OpenAL/AL_SoundHardware.cpp
@@ -187,6 +187,8 @@ int idSoundHardware_OpenAL::GetIndexList( const ALCchar* deviceName ) {
 
 void idSoundHardware_OpenAL::PrintDeviceList( const char* list )
 {
+	int index = 0;
+
 	if( !list || *list == '\0' )
 	{
 		idLib::Printf( "	!!! none !!!\n" );
@@ -195,8 +197,9 @@ void idSoundHardware_OpenAL::PrintDeviceList( const char* list )
 	{
 		do
 		{
-			idLib::Printf( "	%s\n", list );
+			idLib::Printf( "    %i: %s\n", index, list );
 			list += strlen( list ) + 1;
+			index++;
 		}
 		while( *list != '\0' );
 	}
@@ -248,7 +251,9 @@ void idSoundHardware_OpenAL::PrintALInfo()
 	CheckALErrors();
 }
 
+//void idSoundHardware_OpenAL::listDevices_f( const idCmdArgs& args )
 void listDevices_f( const idCmdArgs& args )
+
 {
 	idLib::Printf( "Available playback devices:\n" );
 	if( alcIsExtensionPresent( NULL, "ALC_ENUMERATE_ALL_EXT" ) != AL_FALSE )
@@ -260,6 +265,8 @@ void listDevices_f( const idCmdArgs& args )
 		idSoundHardware_OpenAL::PrintDeviceList( alcGetString( NULL, ALC_DEVICE_SPECIFIER ) );
 	}
 	
+	idLib::Printf( "\n" );
+
 	//idLib::Printf("Available capture devices:\n");
 	//printDeviceList(alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER));
 	
@@ -272,6 +279,12 @@ void listDevices_f( const idCmdArgs& args )
 		idLib::Printf( "Default playback device: %s\n",  alcGetString( NULL, ALC_DEFAULT_DEVICE_SPECIFIER ) );
 	}
 	
+	if( s_device.GetInteger() == -1) {
+		idLib::Printf( "Selected playback device is default's.\n" );
+	} else {
+		idLib::Printf( "Selected playback device is device: %i\n", s_device.GetInteger() ); //FIXME this could bring wrong info if s_device points to a fake number
+	}
+
 	//idLib::Printf("Default capture device: %s\n", alcGetString(NULL, ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER));
 	
 	idSoundHardware_OpenAL::PrintALCInfo( NULL );

--- a/neo/sound/OpenAL/AL_SoundHardware.h
+++ b/neo/sound/OpenAL/AL_SoundHardware.h
@@ -73,7 +73,7 @@ public:
 	{
 		return openalDevice;
 	};
-	
+
 	int				GetNumZombieVoices() const
 	{
 		return zombieVoices.Num();
@@ -87,7 +87,7 @@ public:
 	static void		PrintDeviceList( const char* list );
 	static void		PrintALCInfo( ALCdevice* device );
 	static void		PrintALInfo();
-	
+
 protected:
 	friend class idSoundSample_OpenAL;
 	friend class idSoundVoice_OpenAL;
@@ -104,15 +104,16 @@ private:
 	ALCdevice*			openalDevice;
 	ALCcontext*			openalContext;
 	
-	//idStaticList<ALCdevice*>	openAlDeviceList;
 	idList<ALCdevice*, TAG_AUDIO>	deviceList;
+
+	//void			listDevices_f( const idCmdArgs& args );
 
 	void			ShutDownOpenAlDeviceList();
 	void			RebuildOpenAlDeviceList();
 	void			GetBestDevice();
 	int     		GetIndexList( const ALCchar* deviceName );
 	int					lastResetTime;
-	
+
 	//int				outputChannels;
 	//int				channelMask;
 	

--- a/neo/sound/OpenAL/AL_SoundHardware.h
+++ b/neo/sound/OpenAL/AL_SoundHardware.h
@@ -107,6 +107,7 @@ private:
 	//idStaticList<ALCdevice*>	openAlDeviceList;
 	idList<ALCdevice*, TAG_AUDIO>	deviceList;
 
+	void			ShutDownOpenAlDeviceList();
 	void			RebuildOpenAlDeviceList();
 	void			GetBestDevice();
 	int     		GetIndexList( const ALCchar* deviceName );

--- a/neo/sound/OpenAL/AL_SoundHardware.h
+++ b/neo/sound/OpenAL/AL_SoundHardware.h
@@ -104,14 +104,9 @@ private:
 	ALCdevice*			openalDevice;
 	ALCcontext*			openalContext;
 	
-	idList<ALCdevice*, TAG_AUDIO>	deviceList;
+	idList<const ALCchar *, TAG_AUDIO> OpenALDeviceList;
 
-	//void			listDevices_f( const idCmdArgs& args );
-
-	void			ShutDownOpenAlDeviceList();
-	void			RebuildOpenAlDeviceList();
-	void			GetBestDevice();
-	int     		GetIndexList( const ALCchar* deviceName );
+	void			OpenBestDevice();
 	int					lastResetTime;
 
 	//int				outputChannels;

--- a/neo/sound/OpenAL/AL_SoundHardware.h
+++ b/neo/sound/OpenAL/AL_SoundHardware.h
@@ -104,6 +104,12 @@ private:
 	ALCdevice*			openalDevice;
 	ALCcontext*			openalContext;
 	
+	//idStaticList<ALCdevice*>	openAlDeviceList;
+	idList<ALCdevice*, TAG_AUDIO>	deviceList;
+
+	void			RebuildOpenAlDeviceList();
+	void			GetBestDevice();
+	int     		GetIndexList( const ALCchar* deviceName );
 	int					lastResetTime;
 	
 	//int				outputChannels;


### PR DESCRIPTION
This Branch solves the s_device functionality in OpenAL, originally it had none, you can force the engine to use a specific device as sound device.

as information one searches the reference to the sound device the engine gives with "listDevices"
once you know the "number of the device" you input that number after "s_device"
and then you proceed to "s_restart" 
internally the engine shutdown the device, and init the new device,and so the sound is restarted using the new device